### PR TITLE
Fix ../problems/problems import issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     name: Build problem list and static files
     needs: test
     runs-on: ubuntu-latest
+    env:
+      REACT_APP_PROBLEM_SET: ${{secrets.REACT_APP_PROBLEM_SET}}
     steps:
       - uses: actions/checkout@v4
       - run: git submodule sync

--- a/src/problems
+++ b/src/problems
@@ -1,1 +1,0 @@
-public-problems

--- a/src/problems.ts
+++ b/src/problems.ts
@@ -1,0 +1,24 @@
+
+/**
+ * Here you define the different types of questions
+ */
+const questionTypeList = [
+    'private-problems',
+    'public-problems'
+]
+
+/**
+ * Depending on the REACT_APP_PROBLEM_SET, it returns am ESM module based off that ones
+ * @returns ESM Module Import for the different problems
+ */
+function chooseQuestionType() { 
+    const questionType = process.env.REACT_APP_PROBLEM_SET;
+    
+    if(questionTypeList.includes(questionType!)) {
+        return import(`./${questionType}/problems.js`)
+    } else{
+        throw Error('The env REACT_APP_PROBLEM_SET is incorrect or not set')
+    }
+}
+
+export default chooseQuestionType;

--- a/src/utils/getCategoryList.ts
+++ b/src/utils/getCategoryList.ts
@@ -1,4 +1,6 @@
-import problems from "../problems/problems";
+import chooseQuestionType from "../problems";
+
+const {problems} = await chooseQuestionType()
 
 // TODO: since mutation and haystack aren't considered categories,
 // the array this function returns doesn't contain them. if the issue
@@ -6,7 +8,7 @@ import problems from "../problems/problems";
 export function getCategoryList() {
   const categories = new Set<string>();
 
-  problems.forEach((p) => {
+  problems.forEach((p: any) => {
     categories.add(p.meta.category);
   });
 

--- a/src/utils/getCompletedProblems.ts
+++ b/src/utils/getCompletedProblems.ts
@@ -1,5 +1,7 @@
-import problems from "../problems/problems";
+import chooseQuestionType from "../problems";
 import { Progress, Submission } from "../types";
+
+const {problems} = await chooseQuestionType()
 
 interface CompletedByCategory {
   problems: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
When we first tried to run the app, it would not work. That was because the import `../problems/problems` was not functioning because there was no problems directory.

## I addressed the following:
- Created a handler for what problems to import based on what is in the .env.local
- Changed the target value from es5 to es2022 for tsconfig because es5 was old and was limiting me
- Changed the files that used the original import to use the new one
- Changed private and public problems to export the problem when making the `problem.js` file

## PRs to look at Before This One
<https://github.com/coding-cat-official/coding-cat-private/pull/3>
<https://github.com/coding-cat-official/coding-cat-public/pull/165>