### PR TITLE
 Make source maps not generate on github pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
       REACT_APP_SUPABASE_ANON_KEY: ${{secrets.REACT_APP_SUPABASE_ANON_KEY}}
       REACT_APP_SUPABASE_URL: ${{secrets.REACT_APP_SUPABASE_URL}}
       PUBLIC_URL: /coding-cat
+      GENERATE_SOURCEMAP: false
     steps:
       - uses: actions/checkout@v4
       - run: git submodule sync


### PR DESCRIPTION
Source maps are what allow us to see the tsx files in dev tools. In order to make sure that its not viewable in github pages I added an env to build without sourcemaps

NOTE: We need to do the same for the coding cat deployment

closes #248 