### PR TITLE
Session timer feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "coding-cat",
   "version": "0.1.0",
   "homepage": ".",
+  "type": "module",
   "private": true,
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",

--- a/src/components/PostSessionForm.tsx
+++ b/src/components/PostSessionForm.tsx
@@ -152,7 +152,11 @@ export default function PostSessionForm() {
       }
       console.log("Form answers submitted:", answers);
       setError(null);
-      navigate("/");
+      navigate("/", {
+        state: {
+          fromPostSession: true
+        }
+      });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Unknown error";
       setError(errorMessage);

--- a/src/components/PreSessionForm.tsx
+++ b/src/components/PreSessionForm.tsx
@@ -124,7 +124,7 @@ export default function PreSessionForm() {
       setError("Error submitting session data. Please try again.");
       console.error("Supabase insert error:", error);
     } else {
-      navigate('/', { state: { sessionId: data.id } });
+      navigate('/', { state: { sessionId: data.id, fromPreSession: true } });
     }
   };
 

--- a/src/components/PreSessionForm.tsx
+++ b/src/components/PreSessionForm.tsx
@@ -107,7 +107,6 @@ export default function PreSessionForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const { user } = session!!;
-
     const { data, error} = await supabase
       .from('sessions')
       .insert([{
@@ -116,6 +115,7 @@ export default function PreSessionForm() {
         pre_session_reflection: answers,
         exercise_goals: Number(answers["goals-2"] || 0),
         exercise_categories: answers['goals-3'] || [],
+        planned_duration_minutes: Number(answers['goals-1'])
       }])
       .select()
       .single();

--- a/src/hooks/useEval.tsx
+++ b/src/hooks/useEval.tsx
@@ -13,8 +13,9 @@ export default function useEval(problem: Problem, session: Session | null, refet
 
     // Set eval response to null every time the problem changes
     useEffect(() => { 
-        setEvalResponse(null); 
-    }, [problem]);
+        setEvalResponse(null);
+        currentCodeRef.current = ''; 
+    }, [problem.meta.name]);
 
     // Registers an event that runs whenever proxy.py responds with eval_finished
     useEffect(() => {

--- a/src/hooks/useEval.tsx
+++ b/src/hooks/useEval.tsx
@@ -7,7 +7,13 @@ import { supabase } from '../supabaseClient';
 
 export type Eval = [EvalResponse | null, (code: string) => void];
 
-export default function useEval(problem: Problem, session: Session | null, refetchProgress: () => void): Eval {
+export default function useEval(
+  problem: Problem, 
+  session: Session | null, 
+  refetchProgress: () => void,
+  sessionId?: string | null,
+  problemStartRef?: React.MutableRefObject<number | null>
+): Eval {
     const [evalResponse, setEvalResponse] = useState<EvalResponse | null>(null)
     const currentCodeRef = useRef<string>('');
 
@@ -55,16 +61,26 @@ export default function useEval(problem: Problem, session: Session | null, refet
                     ? currentCodeRef.current
                     : { code: currentCodeRef.current }
     
+                // Calculate time spent on this problem
+                const timeSpentSeconds = problemStartRef?.current 
+                  ? Math.floor((Date.now() - problemStartRef.current) / 1000)
+                  : 0;
+
+                const isSuccessful = numPassed === totalTests;
+
                 // Submission payload
                 const submission = {
                     problem_title: problem.meta.name,
                     problem_category: problem.meta.category,
                     code: submissionPayload,
                     passed_tests: numPassed,
+                    total_tests: totalTests,
                     submitted_at: new Date().toISOString(),
                     profile_id: session.user.id,
-                    total_tests: totalTests,
-                    question_type: problem.meta.question_type[0]
+                    question_type: problem.meta.question_type[0],
+                    successful: isSuccessful,
+                    time_spent_seconds: timeSpentSeconds,
+                    ...(sessionId && { session_id: sessionId })
                 };
                 // Retrieve the most recent submission in the db
                 const { data, error } = await supabase

--- a/src/hooks/useEval.tsx
+++ b/src/hooks/useEval.tsx
@@ -7,13 +7,7 @@ import { supabase } from '../supabaseClient';
 
 export type Eval = [EvalResponse | null, (code: string) => void];
 
-export default function useEval(
-  problem: Problem, 
-  session: Session | null, 
-  refetchProgress: () => void,
-  sessionId?: string | null,
-  problemStartRef?: React.MutableRefObject<number | null>
-): Eval {
+export default function useEval(problem: Problem, session: Session | null, refetchProgress: () => void): Eval {
     const [evalResponse, setEvalResponse] = useState<EvalResponse | null>(null)
     const currentCodeRef = useRef<string>('');
 
@@ -61,26 +55,16 @@ export default function useEval(
                     ? currentCodeRef.current
                     : { code: currentCodeRef.current }
     
-                // Calculate time spent on this problem
-                const timeSpentSeconds = problemStartRef?.current 
-                  ? Math.floor((Date.now() - problemStartRef.current) / 1000)
-                  : 0;
-
-                const isSuccessful = numPassed === totalTests;
-
                 // Submission payload
                 const submission = {
                     problem_title: problem.meta.name,
                     problem_category: problem.meta.category,
                     code: submissionPayload,
                     passed_tests: numPassed,
-                    total_tests: totalTests,
                     submitted_at: new Date().toISOString(),
                     profile_id: session.user.id,
-                    question_type: problem.meta.question_type[0],
-                    successful: isSuccessful,
-                    time_spent_seconds: timeSpentSeconds,
-                    ...(sessionId && { session_id: sessionId })
+                    total_tests: totalTests,
+                    question_type: problem.meta.question_type[0]
                 };
                 // Retrieve the most recent submission in the db
                 const { data, error } = await supabase
@@ -141,4 +125,3 @@ export default function useEval(
 
     return [evalResponse, runCode];
 }
-

--- a/src/hooks/useEval.tsx
+++ b/src/hooks/useEval.tsx
@@ -13,9 +13,8 @@ export default function useEval(problem: Problem, session: Session | null, refet
 
     // Set eval response to null every time the problem changes
     useEffect(() => { 
-        setEvalResponse(null);
-        currentCodeRef.current = ''; 
-    }, [problem.meta.name]);
+        setEvalResponse(null); 
+    }, [problem]);
 
     // Registers an event that runs whenever proxy.py responds with eval_finished
     useEffect(() => {

--- a/src/hooks/useProblemTimer.ts
+++ b/src/hooks/useProblemTimer.ts
@@ -6,13 +6,16 @@ import { ProblemSessionStats, ProblemArgs } from '../types';
  * It starts a timer when the component mounts and stops it when the user completes the problem or navigates away. 
  * The elapsed time is stored in the parent component's state to be included in the session summary.
  */
-export default function useProblemTimer({ problemName, activeSession, problemSessionStats, setProblemSessionStats } : ProblemArgs) {
+export default function useProblemTimer({ problemName, activeSession, problemSessionStats, setProblemSessionStats, progress } : ProblemArgs) {
+    const alreadySolved = progress?.some(
+        s => s.problem_title === problemName && s.passed_tests === s.total_tests
+    ) ?? false;
+    const stats = problemSessionStats[problemName];
+    const completed = stats?.completed ?? alreadySolved;
     const [elapsed, setElapsed] = useState(problemSessionStats[problemName]?.elapsedTimeSeconds ?? 0);
     const intervalRef = useRef<NodeJS.Timeout | null>(null);
     const startRef = useRef<number | null>(null);
     const hasStoppedRef = useRef(false);
-    const stats = problemSessionStats[problemName];
-    const completed = stats?.completed ?? false;
 
     //from the stored state
     useEffect(() => {
@@ -37,6 +40,8 @@ export default function useProblemTimer({ problemName, activeSession, problemSes
                 intervalRef.current = null;
             }
 
+            if (!activeSession) return; 
+            
             if (hasStoppedRef.current) return;
             const delta = Math.floor((Date.now() - (startRef.current ?? Date.now())) / 1000);
 

--- a/src/hooks/useProblemTimer.ts
+++ b/src/hooks/useProblemTimer.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import { ProblemSessionStats, ProblemArgs } from '../types';
+
+/**
+ * This component is responsible for tracking the time spent on a problem during an active session. 
+ * It starts a timer when the component mounts and stops it when the user completes the problem or navigates away. 
+ * The elapsed time is stored in the parent component's state to be included in the session summary.
+ */
+export default function useProblemTimer({ problemName, activeSession, problemSessionStats, setProblemSessionStats } : ProblemArgs) {
+    const [elapsed, setElapsed] = useState(problemSessionStats[problemName]?.elapsedTimeSeconds ?? 0);
+    const intervalRef = useRef<NodeJS.Timeout | null>(null);
+    const startRef = useRef<number | null>(null);
+    const hasStoppedRef = useRef(false);
+    const stats = problemSessionStats[problemName];
+    const completed = stats?.completed ?? false;
+
+    //from the stored state
+    useEffect(() => {
+        if (!activeSession) return;
+        if (completed) return;
+
+        //we don't want duplicate intervals
+        if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+        }
+        startRef.current = Date.now();
+        setElapsed(stats?.elapsedTimeSeconds ?? 0);
+        intervalRef.current = setInterval(() => {
+            const base = stats?.elapsedTimeSeconds ?? 0;
+            const delta = Math.floor((Date.now() - (startRef.current ?? Date.now())) / 1000);
+            setElapsed(base + delta);
+        }, 1000);
+
+        return () => {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+                intervalRef.current = null;
+            }
+
+            if (hasStoppedRef.current) return;
+            const delta = Math.floor((Date.now() - (startRef.current ?? Date.now())) / 1000);
+
+            setProblemSessionStats(prev => ({
+                ...prev,
+                [problemName]: {
+                    elapsedTimeSeconds: (prev[problemName]?.elapsedTimeSeconds ?? 0) + delta,
+                    completed: prev[problemName]?.completed ?? false,
+                    passedTests: prev[problemName]?.passedTests ?? 0,
+                    totalTests: prev[problemName]?.totalTests ?? 0,
+                },
+            }));
+        };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [problemName, activeSession, completed]);
+
+    const stop = (data?: Partial<ProblemSessionStats>) => {
+        hasStoppedRef.current = true;
+
+        if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+        }
+
+        const delta = Math.floor(
+            (Date.now() - (startRef.current ?? Date.now())) / 1000
+        );
+
+        setProblemSessionStats(prev => ({
+            ...prev,
+            [problemName]: {
+                elapsedTimeSeconds: (prev[problemName]?.elapsedTimeSeconds ?? 0) + delta,
+                completed: true,
+                passedTests: data?.passedTests ?? prev[problemName]?.passedTests ?? 0,
+                totalTests: data?.totalTests ?? prev[problemName]?.totalTests ?? 0,
+            }
+        }));
+
+        setElapsed(prev => prev + delta);
+    };
+
+    return { elapsed, stop, completed };
+}
+

--- a/src/hooks/useProblemTimer.ts
+++ b/src/hooks/useProblemTimer.ts
@@ -17,19 +17,32 @@ export default function useProblemTimer({ problemName, activeSession, problemSes
     const startRef = useRef<number | null>(null);
     const hasStoppedRef = useRef(false);
 
+    const completedRef = useRef(completed);
+    completedRef.current = completed;
+
+    //Reset all the variables states
+    useEffect(() => {
+        hasStoppedRef.current = false;
+        startRef.current = null;
+        setElapsed(problemSessionStats[problemName]?.elapsedTimeSeconds ?? 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [problemName]);
+
     //from the stored state
     useEffect(() => {
         if (!activeSession) return;
-        if (completed) return;
+        const currentProblemCompleted = problemSessionStats[problemName]?.completed ?? alreadySolved;
+
+        if (currentProblemCompleted) return;
 
         //we don't want duplicate intervals
         if (intervalRef.current) {
             clearInterval(intervalRef.current);
         }
+        const base = problemSessionStats[problemName]?.elapsedTimeSeconds ?? 0;
         startRef.current = Date.now();
-        setElapsed(stats?.elapsedTimeSeconds ?? 0);
+
         intervalRef.current = setInterval(() => {
-            const base = stats?.elapsedTimeSeconds ?? 0;
             const delta = Math.floor((Date.now() - (startRef.current ?? Date.now())) / 1000);
             setElapsed(base + delta);
         }, 1000);
@@ -41,8 +54,8 @@ export default function useProblemTimer({ problemName, activeSession, problemSes
             }
 
             if (!activeSession) return; 
-            
             if (hasStoppedRef.current) return;
+
             const delta = Math.floor((Date.now() - (startRef.current ?? Date.now())) / 1000);
 
             setProblemSessionStats(prev => ({
@@ -56,7 +69,7 @@ export default function useProblemTimer({ problemName, activeSession, problemSes
             }));
         };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [problemName, activeSession, completed]);
+    }, [problemName, activeSession]);
 
     const stop = (data?: Partial<ProblemSessionStats>) => {
         hasStoppedRef.current = true;

--- a/src/hooks/useProblemTimer.ts
+++ b/src/hooks/useProblemTimer.ts
@@ -17,21 +17,14 @@ export default function useProblemTimer({ problemName, activeSession, problemSes
     const startRef = useRef<number | null>(null);
     const hasStoppedRef = useRef(false);
 
-    const completedRef = useRef(completed);
-    completedRef.current = completed;
-
-    //Reset all the variables states
-    useEffect(() => {
-        hasStoppedRef.current = false;
-        startRef.current = null;
-        setElapsed(problemSessionStats[problemName]?.elapsedTimeSeconds ?? 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [problemName]);
-
     //from the stored state
     useEffect(() => {
         if (!activeSession) return;
-        const currentProblemCompleted = problemSessionStats[problemName]?.completed ?? alreadySolved;
+        hasStoppedRef.current = false;
+        const freshAlreadySolved = progress?.some(
+            s => s.problem_title === problemName && s.passed_tests === s.total_tests
+        ) ?? false;
+        const currentProblemCompleted = problemSessionStats[problemName]?.completed ?? freshAlreadySolved;
 
         if (currentProblemCompleted) return;
 

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -206,6 +206,14 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
 
   }, [problem.meta.name, problem.meta.question_type, problem.starter, session, setCode]);
 
+  useEffect(() => {
+  const existingStats = problemSessionStats[problem.meta.name];
+
+  setProblemElapsedSeconds(existingStats?.elapsedTimeSeconds ?? 0);
+
+// eslint-disable-next-line react-hooks/exhaustive-deps
+}, [problem.meta.name]);
+
     // Problem timer, starts when problem loads
     useEffect(() => {
       if (!activeSession) return;
@@ -213,11 +221,20 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       const existingStats = problemSessionStats[problem.meta.name];
 
       //we don't want to restart already completed problems
-      if (existingStats?.completed){
+      if (existingStats?.completed === true) {
         setProblemElapsedSeconds(existingStats.elapsedTimeSeconds);
+
+        if (problemTimerRef.current) {
+          clearInterval(problemTimerRef.current);
+          problemTimerRef.current = null;
+        }
+
         return;
       }
 
+      if (problemTimerRef.current) {
+        clearInterval(problemTimerRef.current);
+    }
       problemStartRef.current = Date.now();
 
       problemTimerRef.current = setInterval(() => {
@@ -245,7 +262,8 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
         }))
       }
 
-    }, [problem.meta.name, activeSession, problemSessionStats, setProblemSessionStats]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [problem.meta.name, activeSession]);
 
     // Alert user if taking too long on a problem
     useEffect(() => {

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -56,6 +56,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     const [problems, setProblems] = useState<Problem[]>([]);
     const [problemElapsedSeconds, setProblemElapsedSeconds] = useState(0);
     const [problemAlertStage, setProblemAlertStage] = useState<null | 'half' | 'twoThirds'>(null);
+    const [hideExerciseTimer, setHideExerciseTimer] = useState(false);
     const problemTimerRef = useRef<NodeJS.Timeout | null>(null);
     const problemStartRef = useRef<number | null>(null);
 
@@ -216,9 +217,11 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
 
       if (problemElapsedSeconds >= perProblemTarget * (2/3) && problemAlertStage !== 'twoThirds') {
         setProblemAlertStage('twoThirds');
+        setHideExerciseTimer(false);
         console.warn(`You've been on this problem for ${Math.floor(problemElapsedSeconds / 60)} minutes. Consider using debugging tools or moving on.`);
       } else if (problemElapsedSeconds >= perProblemTarget / 2 && problemAlertStage !== 'half') {
         setProblemAlertStage('half');
+        setHideExerciseTimer(false);
         console.log(`You've spent ${Math.floor(problemElapsedSeconds / 60)} minutes on this problem.`);
       }
     }, [problemElapsedSeconds, plannedExerciseCount, sessionDuration, activeSession, problemAlertStage]);
@@ -286,7 +289,49 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
               </Markdown>
               {['coding','haystack'].includes(problem.meta.question_type[0]) ? <></> : <Tutorial tourState={isTourOpen} setTourState={setTourOpen}/>}
             </Box>
+
+            {activeSession && (
+              hideExerciseTimer ? (
+                <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+                  <Button
+                    size="sm"
+                    variant="soft"
+                    color="neutral"
+                    onClick={() => setHideExerciseTimer(false)}
+                    sx={{ borderRadius: '999px', textTransform: 'none' }}
+                  >
+                    Show exercise timer
+                  </Button>
+                </Box>
+              ) : (
+                <Box sx={{
+                  width: '100%',
+                  mt: 2,
+                  p: 1,
+                  borderRadius: '999px',
+                  background: 'linear-gradient(90deg, #ff9a9e 0%, #fad0c4 50%, #f9d976 100%)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                }}>
+                  <Typography level="body-md" sx={{ fontWeight: 700, color: '#3f2d2d' }}>
+                    Exercise timer: {Math.floor(problemElapsedSeconds / 60)}:{(problemElapsedSeconds % 60).toString().padStart(2, '0')} elapsed
+                  </Typography>
+                  <Button
+                    size="sm"
+                    variant="plain"
+                    color="neutral"
+                    onClick={() => setHideExerciseTimer(true)}
+                    sx={{ minWidth: '24px', px: 0, color: '#3f2d2d' }}
+                  >
+                    ×
+                  </Button>
+                </Box>
+              )
+            )}
           </Box>
+
           { ['coding','haystack'].includes(problem.meta.question_type[0]) ?
             (
               <CodingQuestion code={code} changeCode={changeCode} problem={problem} runCode={runCode} />

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -48,20 +48,38 @@ interface ProblemIDEProps {
 }
 
 function ProblemIDE({ problem }: ProblemIDEProps) {
-  const [code, setCode] = usePersistentProblemCode(problem);
-  const [hidePrompt, setHidePrompt] = useState(true);
-  const [question, setQuestion] = useState("");
-  const reflectionInput = useRef<HTMLElement>(null);
-  const [isTourOpen, setTourOpen] = useState(false);
-  const [problems, setProblems] = useState<Problem[]>([]);
+    const [code, setCode] = usePersistentProblemCode(problem);
+    const [hidePrompt, setHidePrompt] = useState(true);
+    const [question, setQuestion] = useState("");
+    const reflectionInput = useRef<HTMLElement>(null);
+    const [isTourOpen, setTourOpen] = useState(false);
+    const [problems, setProblems] = useState<Problem[]>([]);
+    const [problemElapsedSeconds, setProblemElapsedSeconds] = useState(0);
+    const [problemAlertStage, setProblemAlertStage] = useState<null | 'half' | 'twoThirds'>(null);
+    const problemTimerRef = useRef<NodeJS.Timeout | null>(null);
+    const problemStartRef = useRef<number | null>(null);
 
-  const { session, setActiveProblem, refetchProgress } = useOutletContext<{
-    session: Session | null,
-    setActiveProblem: (name: string | null) => void,
-    refetchProgress: () => void
-  }>();
-  
-  const navigate = useNavigate();
+    const { 
+      session, 
+      setActiveProblem, 
+      refetchProgress,
+      activeSession,
+      sessionId,
+      sessionRemainingSeconds,
+      sessionDuration,
+      plannedExerciseCount
+    } = useOutletContext<{
+      session: Session | null,
+      setActiveProblem: (name: string | null) => void,
+      refetchProgress: () => void,
+      activeSession: boolean,
+      sessionId: string | null,
+      sessionRemainingSeconds: number,
+      sessionDuration: number,
+      plannedExerciseCount: number
+    }>();
+    
+    const navigate = useNavigate();
 
   useEffect(() => {
     (async () => {
@@ -138,7 +156,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
         .select('code')
         .eq('profile_id', session.user.id)
         .eq('problem_title', problem.meta.name)
-        .order('submitted_at', { ascending: false})
+        .order('submitted_at', { ascending: false })
         .limit(1);
 
       const json = data?.[0] || null;
@@ -147,8 +165,8 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
         console.warn('Could not load latest submission: ', error.message);
         return;
       }
-      
-      if (json){
+
+      if (json) {
         if (problem.meta.question_type[0] === 'mutation') {
           setCode(json.code);
         } else {
@@ -160,23 +178,54 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
           );
         }
       } else {
-        if(['coding','haystack'].includes(problem.meta.question_type[0])){
+        if (['coding', 'haystack'].includes(problem.meta.question_type[0])) {
           setCode(problem.starter || '');
         }
-        else{
+        else {
           setCode('');
         }
       }
-      hasFetchedProblems.current.add(problem.meta.name);
     }
-
     fetchLatestSubmission();
 
   }, [problem.meta.name, problem.meta.question_type, problem.starter, session, setCode]);
 
-  function changeCode(e: string | undefined) {
-    setCode(e ?? '')
-  }
+    // Problem timer - starts when problem loads
+    useEffect(() => {
+      problemStartRef.current = Date.now();
+      setProblemElapsedSeconds(0);
+      setProblemAlertStage(null);
+
+      problemTimerRef.current = setInterval(() => {
+        if (!problemStartRef.current) return;
+        const elapsed = Math.floor((Date.now() - problemStartRef.current) / 1000);
+        setProblemElapsedSeconds(elapsed);
+      }, 1000);
+
+      return () => {
+        if (problemTimerRef.current) clearInterval(problemTimerRef.current);
+      };
+    }, [problem.meta.name]);
+
+    // Alert user if taking too long on a problem
+    useEffect(() => {
+      if (!activeSession || plannedExerciseCount <= 0 || sessionDuration <= 0) return;
+
+      const sessionSeconds = sessionDuration * 60;
+      const perProblemTarget = Math.max(1, Math.floor(sessionSeconds / Math.max(1, plannedExerciseCount)));
+
+      if (problemElapsedSeconds >= perProblemTarget * (2/3) && problemAlertStage !== 'twoThirds') {
+        setProblemAlertStage('twoThirds');
+        console.warn(`You've been on this problem for ${Math.floor(problemElapsedSeconds / 60)} minutes. Consider using debugging tools or moving on.`);
+      } else if (problemElapsedSeconds >= perProblemTarget / 2 && problemAlertStage !== 'half') {
+        setProblemAlertStage('half');
+        console.log(`You've spent ${Math.floor(problemElapsedSeconds / 60)} minutes on this problem.`);
+      }
+    }, [problemElapsedSeconds, plannedExerciseCount, sessionDuration, activeSession, problemAlertStage]);
+
+    function changeCode(e: string | undefined) {
+      setCode(e ?? '')
+    }
 
 
   function handlePreviousProblem(){

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -68,12 +68,14 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       plannedExerciseCount,
       problemSessionStats,
       setProblemSessionStats,
-      progress
-    } = useOutletContext<{
+      progress,
+      sessionTimerRunning
+     } = useOutletContext<{
       session: Session | null,
       setActiveProblem: (name: string | null) => void,
       refetchProgress: () => void,
       activeSession: boolean,
+      sessionTimerRunning: boolean,
       sessionId: string | null,
       sessionRemainingSeconds: number,
       sessionDuration: number,
@@ -99,7 +101,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     stop: stopTimer,
   } = useProblemTimer({
     problemName: problem.meta.name,
-    activeSession,
+    activeSession: sessionTimerRunning,
     problemSessionStats,
     setProblemSessionStats,
     progress,
@@ -234,7 +236,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
  
     // Alert user if taking too long on a problem
     useEffect(() => {
-      if (!activeSession || plannedExerciseCount <= 0 || sessionDuration <= 0) return;
+      if (!sessionTimerRunning || plannedExerciseCount <= 0 || sessionDuration <= 0) return;
 
       const sessionSeconds = sessionDuration * 60;
       const perProblemTarget = Math.max(1, Math.floor(sessionSeconds / Math.max(1, plannedExerciseCount)));
@@ -244,7 +246,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
         setHideExerciseTimer(false);
         setAlertMessage(`You've been on this problem for a while 🐱 Consider using your tools, asking for hints or moving on!`);
       }
-    }, [problemElapsedSeconds, plannedExerciseCount, sessionDuration, activeSession, problemAlertStage]);
+    }, [problemElapsedSeconds, plannedExerciseCount, sessionDuration, sessionTimerRunning, problemAlertStage]);
 
     useEffect(() => {
       setAlertMessage(null);
@@ -342,7 +344,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
               </Box>
             )}
 
-            {activeSession && !isCompleted && (
+            {sessionTimerRunning && !isCompleted && (
               hideExerciseTimer ? (
                 <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                   <Button

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -64,7 +64,6 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       session, 
       setActiveProblem, 
       refetchProgress,
-      activeSession,
       sessionDuration,
       plannedExerciseCount,
       problemSessionStats,

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -66,7 +66,9 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       refetchProgress,
       activeSession,
       sessionDuration,
-      plannedExerciseCount
+      plannedExerciseCount,
+      problemSessionStats,
+      setProblemSessionStats
     } = useOutletContext<{
       session: Session | null,
       setActiveProblem: (name: string | null) => void,
@@ -75,7 +77,21 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       sessionId: string | null,
       sessionRemainingSeconds: number,
       sessionDuration: number,
-      plannedExerciseCount: number
+      plannedExerciseCount: number,
+      problemSessionStats: Record<string, {
+        elapsedTimeSeconds: number;
+        completed: boolean;
+        passedTests: number;
+        totalTests: number;
+      }>,
+      setProblemSessionStats: React.Dispatch<React.SetStateAction<Record<string, {
+        elapsedTimeSeconds: number;
+        completed: boolean;
+        passedTests: number;
+        totalTests: number;
+      }>
+      >
+      >
     }>();
     
     const navigate = useNavigate();
@@ -190,22 +206,46 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
 
   }, [problem.meta.name, problem.meta.question_type, problem.starter, session, setCode]);
 
-    // Problem timer - starts when problem loads
+    // Problem timer, starts when problem loads
     useEffect(() => {
+      if (!activeSession) return;
+
+      const existingStats = problemSessionStats[problem.meta.name];
+
+      //we don't want to restart already completed problems
+      if (existingStats?.completed){
+        setProblemElapsedSeconds(existingStats.elapsedTimeSeconds);
+        return;
+      }
+
       problemStartRef.current = Date.now();
-      setProblemElapsedSeconds(0);
-      setProblemAlertStage(null);
 
       problemTimerRef.current = setInterval(() => {
-        if (!problemStartRef.current) return;
-        const elapsed = Math.floor((Date.now() - problemStartRef.current) / 1000);
-        setProblemElapsedSeconds(elapsed);
+        const startElapsed = existingStats?.elapsedTimeSeconds ?? 0;
+        const currentElapsed = Math.floor((Date.now() - (problemStartRef.current ?? Date.now())) / 1000);
+
+        setProblemElapsedSeconds(startElapsed + currentElapsed);
       }, 1000);
 
       return () => {
-        if (problemTimerRef.current) clearInterval(problemTimerRef.current);
-      };
-    }, [problem.meta.name]);
+        if (problemTimerRef.current) {
+          clearInterval(problemTimerRef.current);
+        }
+
+        const additionalElapsed = Math.floor((Date.now() - (problemStartRef.current ?? Date.now())) / 1000);
+
+        setProblemSessionStats(prev => ({
+          ...prev,
+          [problem.meta.name]: {
+            elapsedTimeSeconds: (prev[problem.meta.name]?.elapsedTimeSeconds ?? 0) + additionalElapsed,
+            completed: false,
+            passedTests: prev[problem.meta.name]?.passedTests ?? 0,
+            totalTests: prev[problem.meta.name]?.totalTests ?? 0,
+          }
+        }))
+      }
+
+    }, [problem.meta.name, activeSession, problemSessionStats, setProblemSessionStats]);
 
     // Alert user if taking too long on a problem
     useEffect(() => {
@@ -225,10 +265,37 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       }
     }, [problemElapsedSeconds, plannedExerciseCount, sessionDuration, activeSession, problemAlertStage]);
 
+    // We want to stop the timer permanently when all the tests pass
+    useEffect(() => {
+      if (!evalResponse || evalResponse.status !== 'success') return;
+
+      const allPassed = evalResponse.report.every(r => r.equal);
+      if (!allPassed) return;
+
+      //stop the timer
+      if(problemTimerRef.current) {
+        clearInterval(problemTimerRef.current);
+        problemTimerRef.current = null;
+      }
+
+      //then calculate the final elapsed time
+      const additionalElapsed  = Math.floor((Date.now() - (problemStartRef.current ?? Date.now())) / 1000);
+      setProblemSessionStats(prev => ({
+        ...prev,
+        [problem.meta.name]: {
+          elapsedTimeSeconds: (prev[problem.meta.name]?.elapsedTimeSeconds ?? 0) + additionalElapsed,
+          completed: true,
+          passedTests: evalResponse.report.filter(r => r.equal).length,
+          totalTests: evalResponse.report.length,
+        }
+      }));
+
+      setProblemElapsedSeconds(prev => prev + additionalElapsed);
+    }, [evalResponse, problem.meta.name, setProblemSessionStats]);
+
     function changeCode(e: string | undefined) {
       setCode(e ?? '')
     }
-
 
   function handlePreviousProblem(){
     if(currIndex > 0){
@@ -289,7 +356,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
               {['coding','haystack'].includes(problem.meta.question_type[0]) ? <></> : <Tutorial tourState={isTourOpen} setTourState={setTourOpen}/>}
             </Box>
 
-            {activeSession && (
+            {activeSession && !problemSessionStats[problem.meta.name]?.completed && (
               hideExerciseTimer ? (
                 <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                   <Button

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -20,6 +20,7 @@ import cursedCat from '../assets/cUrSed.png';
 import SolutionCode from '../components/SolutionCode';
 import { getColumnStatuses } from '../utils/mapMutantResults';
 import getProblemSet from '../utils/getProblemSet';
+import useProblemTimer from '../hooks/useProblemTimer';
 
 // Emoji rendered in the report
 const ALL_TESTS_PASSED = '🎉';
@@ -54,11 +55,8 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     const reflectionInput = useRef<HTMLElement>(null);
     const [isTourOpen, setTourOpen] = useState(false);
     const [problems, setProblems] = useState<Problem[]>([]);
-    const [problemElapsedSeconds, setProblemElapsedSeconds] = useState(0);
     const [problemAlertStage, setProblemAlertStage] = useState<null | 'half' | 'twoThirds'>(null);
     const [hideExerciseTimer, setHideExerciseTimer] = useState(false);
-    const problemTimerRef = useRef<NodeJS.Timeout | null>(null);
-    const problemStartRef = useRef<number | null>(null);
 
     const { 
       session, 
@@ -93,6 +91,17 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       >
       >
     }>();
+
+  const {
+    elapsed: problemElapsedSeconds,
+    completed: isCompleted,
+    stop: stopTimer,
+  } = useProblemTimer({
+    problemName: problem.meta.name,
+    activeSession,
+    problemSessionStats,
+    setProblemSessionStats,
+  });
     
     const navigate = useNavigate();
 
@@ -126,6 +135,19 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
   }, [setActiveProblem, problem.meta.name, currProblems]);
 
   const [evalResponse, runCode] = useEval(problem, session, refetchProgress);
+
+
+  useEffect(() => {
+    if (!evalResponse || evalResponse?.status !== "success") return;
+
+    const passedTests = evalResponse.report.filter((r) => r.equal).length;
+    const totalTests = evalResponse.report.length;
+    const allPassed = passedTests === totalTests;
+
+    if (allPassed && !isCompleted) {
+      stopTimer({ passedTests, totalTests });
+    }
+  }, [evalResponse, stopTimer, isCompleted]);
 
 
   // Function for defining what reflection questions to show to user depending on success status of user code
@@ -206,65 +228,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
 
   }, [problem.meta.name, problem.meta.question_type, problem.starter, session, setCode]);
 
-  useEffect(() => {
-  const existingStats = problemSessionStats[problem.meta.name];
-
-  setProblemElapsedSeconds(existingStats?.elapsedTimeSeconds ?? 0);
-
-// eslint-disable-next-line react-hooks/exhaustive-deps
-}, [problem.meta.name]);
-
-    // Problem timer, starts when problem loads
-    useEffect(() => {
-      if (!activeSession) return;
-
-      const existingStats = problemSessionStats[problem.meta.name];
-
-      //we don't want to restart already completed problems
-      if (existingStats?.completed === true) {
-        setProblemElapsedSeconds(existingStats.elapsedTimeSeconds);
-
-        if (problemTimerRef.current) {
-          clearInterval(problemTimerRef.current);
-          problemTimerRef.current = null;
-        }
-
-        return;
-      }
-
-      if (problemTimerRef.current) {
-        clearInterval(problemTimerRef.current);
-    }
-      problemStartRef.current = Date.now();
-
-      problemTimerRef.current = setInterval(() => {
-        const startElapsed = existingStats?.elapsedTimeSeconds ?? 0;
-        const currentElapsed = Math.floor((Date.now() - (problemStartRef.current ?? Date.now())) / 1000);
-
-        setProblemElapsedSeconds(startElapsed + currentElapsed);
-      }, 1000);
-
-      return () => {
-        if (problemTimerRef.current) {
-          clearInterval(problemTimerRef.current);
-        }
-
-        const additionalElapsed = Math.floor((Date.now() - (problemStartRef.current ?? Date.now())) / 1000);
-
-        setProblemSessionStats(prev => ({
-          ...prev,
-          [problem.meta.name]: {
-            elapsedTimeSeconds: (prev[problem.meta.name]?.elapsedTimeSeconds ?? 0) + additionalElapsed,
-            completed: false,
-            passedTests: prev[problem.meta.name]?.passedTests ?? 0,
-            totalTests: prev[problem.meta.name]?.totalTests ?? 0,
-          }
-        }))
-      }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [problem.meta.name, activeSession]);
-
+ 
     // Alert user if taking too long on a problem
     useEffect(() => {
       if (!activeSession || plannedExerciseCount <= 0 || sessionDuration <= 0) return;
@@ -282,34 +246,6 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
         console.log(`You've spent ${Math.floor(problemElapsedSeconds / 60)} minutes on this problem.`);
       }
     }, [problemElapsedSeconds, plannedExerciseCount, sessionDuration, activeSession, problemAlertStage]);
-
-    // We want to stop the timer permanently when all the tests pass
-    useEffect(() => {
-      if (!evalResponse || evalResponse.status !== 'success') return;
-
-      const allPassed = evalResponse.report.every(r => r.equal);
-      if (!allPassed) return;
-
-      //stop the timer
-      if(problemTimerRef.current) {
-        clearInterval(problemTimerRef.current);
-        problemTimerRef.current = null;
-      }
-
-      //then calculate the final elapsed time
-      const additionalElapsed  = Math.floor((Date.now() - (problemStartRef.current ?? Date.now())) / 1000);
-      setProblemSessionStats(prev => ({
-        ...prev,
-        [problem.meta.name]: {
-          elapsedTimeSeconds: (prev[problem.meta.name]?.elapsedTimeSeconds ?? 0) + additionalElapsed,
-          completed: true,
-          passedTests: evalResponse.report.filter(r => r.equal).length,
-          totalTests: evalResponse.report.length,
-        }
-      }));
-
-      setProblemElapsedSeconds(prev => prev + additionalElapsed);
-    }, [evalResponse, problem.meta.name, setProblemSessionStats]);
 
     function changeCode(e: string | undefined) {
       setCode(e ?? '')
@@ -374,7 +310,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
               {['coding','haystack'].includes(problem.meta.question_type[0]) ? <></> : <Tutorial tourState={isTourOpen} setTourState={setTourOpen}/>}
             </Box>
 
-            {activeSession && !problemSessionStats[problem.meta.name]?.completed && (
+            {activeSession && !isCompleted && (
               hideExerciseTimer ? (
                 <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                   <Button

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -186,6 +186,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
           setCode('');
         }
       }
+      hasFetchedProblems.current.add(problem.meta.name);
     }
     fetchLatestSubmission();
 

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -39,7 +39,7 @@ export default function ProblemView() {
   const problem = useLoaderData() as Problem;
   return (
     <>
-      <ProblemIDE problem={problem} />
+      <ProblemIDE key={problem.meta.name} problem={problem} />
     </>
   );
 }
@@ -149,7 +149,8 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     if (allPassed && !isCompleted) {
       stopTimer({ passedTests, totalTests });
     }
-  }, [evalResponse, stopTimer, isCompleted]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [evalResponse, isCompleted]);
 
 
   // Function for defining what reflection questions to show to user depending on success status of user code

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -65,8 +65,6 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       setActiveProblem, 
       refetchProgress,
       activeSession,
-      sessionId,
-      sessionRemainingSeconds,
       sessionDuration,
       plannedExerciseCount
     } = useOutletContext<{

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -55,7 +55,8 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     const reflectionInput = useRef<HTMLElement>(null);
     const [isTourOpen, setTourOpen] = useState(false);
     const [problems, setProblems] = useState<Problem[]>([]);
-    const [problemAlertStage, setProblemAlertStage] = useState<null | 'half' | 'twoThirds'>(null);
+    const [problemAlertStage, setProblemAlertStage] = useState<null | 'twoThirds'>(null);
+    const [alertMessage, setAlertMessage] = useState<string | null>(null);
     const [hideExerciseTimer, setHideExerciseTimer] = useState(false);
 
     const { 
@@ -66,7 +67,8 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       sessionDuration,
       plannedExerciseCount,
       problemSessionStats,
-      setProblemSessionStats
+      setProblemSessionStats,
+      progress
     } = useOutletContext<{
       session: Session | null,
       setActiveProblem: (name: string | null) => void,
@@ -87,9 +89,8 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
         completed: boolean;
         passedTests: number;
         totalTests: number;
-      }>
-      >
-      >
+      }>>>,
+      progress: { problem_title: string; passed_tests: number; total_tests: number }[]
     }>();
 
   const {
@@ -101,6 +102,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     activeSession,
     problemSessionStats,
     setProblemSessionStats,
+    progress,
   });
     
     const navigate = useNavigate();
@@ -239,13 +241,14 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       if (problemElapsedSeconds >= perProblemTarget * (2/3) && problemAlertStage !== 'twoThirds') {
         setProblemAlertStage('twoThirds');
         setHideExerciseTimer(false);
-        console.warn(`You've been on this problem for ${Math.floor(problemElapsedSeconds / 60)} minutes. Consider using debugging tools or moving on.`);
-      } else if (problemElapsedSeconds >= perProblemTarget / 2 && problemAlertStage !== 'half') {
-        setProblemAlertStage('half');
-        setHideExerciseTimer(false);
-        console.log(`You've spent ${Math.floor(problemElapsedSeconds / 60)} minutes on this problem.`);
+        setAlertMessage(`You've been on this problem for a while 🐱 Consider using your tools, asking for hints or moving on!`);
       }
     }, [problemElapsedSeconds, plannedExerciseCount, sessionDuration, activeSession, problemAlertStage]);
+
+    useEffect(() => {
+      setAlertMessage(null);
+      setProblemAlertStage(null);
+    }, [problem.meta.name]);
 
     function changeCode(e: string | undefined) {
       setCode(e ?? '')
@@ -309,6 +312,34 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
               </Markdown>
               {['coding','haystack'].includes(problem.meta.question_type[0]) ? <></> : <Tutorial tourState={isTourOpen} setTourState={setTourOpen}/>}
             </Box>
+
+            {alertMessage && (
+              <Box sx={{
+                width: '100%',
+                mt: 1,
+                p: 1.5,
+                borderRadius: '12px',
+                backgroundColor: '#ffe0b2',
+                border: '#ffb74d',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 2,
+              }}>
+                <Typography level="body-sm" sx={{ color: '#3f2d2d' }}>
+                  {alertMessage}
+                </Typography>
+                <Button
+                  size="sm"
+                  variant="plain"
+                  color="neutral"
+                  onClick={() => setAlertMessage(null)}
+                  sx={{ minWidth: '24px', px: 0, color: '#3f2d2d' }}
+                >
+                  ×
+                </Button>
+              </Box>
+            )}
 
             {activeSession && !isCompleted && (
               hideExerciseTimer ? (

--- a/src/routes/ProblemView.tsx
+++ b/src/routes/ProblemView.tsx
@@ -58,6 +58,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     const [problemAlertStage, setProblemAlertStage] = useState<null | 'twoThirds'>(null);
     const [alertMessage, setAlertMessage] = useState<string | null>(null);
     const [hideExerciseTimer, setHideExerciseTimer] = useState(false);
+    const latestProblemNameRef = useRef(problem.meta.name);
 
     const { 
       session, 
@@ -107,7 +108,9 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     progress,
   });
     
-    const navigate = useNavigate();
+  const navigate = useNavigate();
+
+  latestProblemNameRef.current = problem.meta.name;
 
   useEffect(() => {
     (async () => {
@@ -143,6 +146,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
 
   useEffect(() => {
     if (!evalResponse || evalResponse?.status !== "success") return;
+    if (latestProblemNameRef.current !== problem.meta.name) return; 
 
     const passedTests = evalResponse.report.filter((r) => r.equal).length;
     const totalTests = evalResponse.report.length;
@@ -152,7 +156,7 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
       stopTimer({ passedTests, totalTests });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [evalResponse, isCompleted]);
+  }, [evalResponse, isCompleted, problem.meta.name]);
 
 
   // Function for defining what reflection questions to show to user depending on success status of user code
@@ -192,6 +196,13 @@ function ProblemIDE({ problem }: ProblemIDEProps) {
     async function fetchLatestSubmission() {
       if (!session?.user) return;
       if (hasFetchedProblems.current.has(problem.meta.name)) return;
+
+      // If localStorage already has code for the problem we don't overwrite it
+      const localCode = localStorage.getItem(problem.meta.name);
+      if (localCode) {
+        hasFetchedProblems.current.add(problem.meta.name);
+        return;
+      }
 
       const { data, error } = await supabase
         .from('submissions')

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -464,6 +464,7 @@ export default function App() {
             session, 
             isAdmin, 
             refetchProgress: fetchProgress,
+            refetchProfile: fetchProfile,
             activeSession,
             sessionId,
             sessionRemainingSeconds,

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Outlet, useLoaderData, useNavigate, useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
-import { BLANK_CONTRACT, BlogPost, ContractData, ContractProgress, Problem, Submission } from '../types';
+import { BLANK_CONTRACT, BlogPost, ContractData, ContractProgress, Problem, ProblemSessionStats, Submission } from '../types';
 import { supabase } from '../supabaseClient';
 import { type Session } from '@supabase/supabase-js';
 import { List as ListIcon } from '@phosphor-icons/react';
@@ -52,6 +52,7 @@ export default function App() {
   const [selectedTab, setSelectedTab] = useState("");
   const [contract, setContract] = useState<ContractData>(BLANK_CONTRACT);
   const [progress, setProgress] = useState<Submission[]>([]);
+  const [problemSessionStats, setProblemSessionStats] = useState<Record<string, ProblemSessionStats>>({});
 
   const contractProgress: ContractProgress = contract.Coding.problemsToSolveByCategory;
   contractProgress["mutation"] = contract.Mutation.problemsToSolve;
@@ -223,6 +224,7 @@ export default function App() {
     setSessionStartTime(null);
     setSessionDuration(0);
     setSessionRemainingSeconds(0);
+    setProblemSessionStats({});
   };
 
   const formatTime = (seconds: number): string => {
@@ -469,7 +471,9 @@ export default function App() {
             sessionId,
             sessionRemainingSeconds,
             sessionDuration,
-            plannedExerciseCount
+            plannedExerciseCount,
+            problemSessionStats,
+            setProblemSessionStats
           }} />
         </Box>
         

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Outlet, useLoaderData, useNavigate } from 'react-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Outlet, useLoaderData, useNavigate, useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
 import { BLANK_CONTRACT, BlogPost, ContractData, ContractProgress, Problem, Submission } from '../types';
 import { supabase } from '../supabaseClient';
@@ -28,11 +28,18 @@ interface UserData{
 // The main thing that needs to be done is putting the `Drawer` component into its own separate file.
 export default function App() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [session, setSession] = useState<Session | null>(null);
   const [userData, setUserData] = useState<UserData | null>(null);
+  const [activeSession, setActiveSession] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionDuration, setSessionDuration] = useState<number>(0);
+  const [sessionStartTime, setSessionStartTime] = useState<Date | null>(null);
+  const [sessionRemainingSeconds, setSessionRemainingSeconds] = useState<number>(0);
+  const [plannedExerciseCount, setPlannedExerciseCount] = useState<number>(0);
+  const sessionTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [isRecoverySession, setIsRecoverySession] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [activeSession, setActiveSession] = useState(false);
   const [open, setOpen] = useState(false);
   const [openCategory, setOpenCategory] = useState(false);
   const [activeProblem, setActiveProblem] = useState<null | string>(null);
@@ -200,6 +207,65 @@ export default function App() {
     closeDrawer: () => setOpen(false)
   };
 
+  const startSession = (sessionIdFromState: string, durationMinutes: number, exerciseCount: number) => {
+    setSessionId(sessionIdFromState);
+    setSessionDuration(durationMinutes);
+    setPlannedExerciseCount(exerciseCount);
+    setSessionStartTime(new Date());
+    setSessionRemainingSeconds(durationMinutes * 60);
+    setActiveSession(true);
+  };
+
+  const endSession = () => {
+    if (sessionTimerRef.current) clearInterval(sessionTimerRef.current);
+    setActiveSession(false);
+    setSessionId(null);
+    setSessionStartTime(null);
+    setSessionDuration(0);
+    setSessionRemainingSeconds(0);
+  };
+
+  // Handle session start when coming back from PreSessionForm
+  useEffect(() => {
+    const sessionIdFromState = (location.state as any)?.sessionId;
+    if (sessionIdFromState && session?.user) {
+      const fetchSessionData = async () => {
+        const { data, error } = await supabase
+          .from('sessions')
+          .select('planned_duration_minutes, exercise_goals')
+          .eq('id', sessionIdFromState)
+          .eq('profile_id', session.user.id)
+          .single();
+
+        if (!error && data) {
+          startSession(sessionIdFromState, data.planned_duration_minutes, data.exercise_goals);
+        }
+      };
+      fetchSessionData();
+    }
+  }, [location.state, session?.user]);
+
+  // Session countdown timer
+  useEffect(() => {
+    if (!activeSession || !sessionStartTime) return;
+
+    sessionTimerRef.current = setInterval(() => {
+      const elapsed = Math.floor((new Date().getTime() - sessionStartTime.getTime()) / 1000);
+      const remaining = Math.max(0, sessionDuration * 60 - elapsed);
+      setSessionRemainingSeconds(remaining);
+
+      if (remaining <= 0) {
+        clearInterval(sessionTimerRef.current!);
+        // Session ended - user should be prompted to post-session
+        // Don't navigate automatically, let them finish current problem
+      }
+    }, 1000);
+
+    return () => {
+      if (sessionTimerRef.current) clearInterval(sessionTimerRef.current);
+    };
+  }, [activeSession, sessionStartTime, sessionDuration]);
+
   return (
     <Box sx={{ display:'flex', height: "100%", flex: 1}}>
       <Stack
@@ -309,13 +375,14 @@ export default function App() {
                   <Button 
                     onClick={() => {
                       if (activeSession) {
-                        // TODO: Implement end session logic
-                        setActiveSession(false);
+                        endSession();
+                        navigate('/post-session', { state: { sessionId } });
                       } else {
                         navigate('/session');
                       }
                     }}
                     sx={{ backgroundColor: activeSession ? '#ffb5a9' : '#d4ff99' }}
+                    title={activeSession ? "Click to end session" : "Start a new session"}
                   >
                     {activeSession ? 'Ongoing Session' : 'Start Session'}
                   </Button>
@@ -365,17 +432,17 @@ export default function App() {
         </Stack>
         
         <Box width="100%" height="100%">
-          <Outlet 
-            context={
-              { 
-                setActiveProblem, 
-                session, 
-                isAdmin, 
-                refetchProgress: fetchProgress,
-                refetchProfile: fetchProfile 
-              }
-            }
-          />
+          <Outlet context={{ 
+            setActiveProblem, 
+            session, 
+            isAdmin, 
+            refetchProgress: fetchProgress,
+            activeSession,
+            sessionId,
+            sessionRemainingSeconds,
+            sessionDuration,
+            plannedExerciseCount
+          }} />
         </Box>
         
       </Stack>

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -293,6 +293,7 @@ export default function App() {
     return () => {
       if (sessionTimerRef.current) clearInterval(sessionTimerRef.current);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSession, sessionStartTime, sessionDuration]);
 
   return (

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -225,25 +225,34 @@ export default function App() {
     setSessionRemainingSeconds(0);
   };
 
+  const formatTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
   // Handle session start when coming back from PreSessionForm
   useEffect(() => {
-    const sessionIdFromState = (location.state as any)?.sessionId;
-    if (sessionIdFromState && session?.user) {
-      const fetchSessionData = async () => {
-        const { data, error } = await supabase
-          .from('sessions')
-          .select('planned_duration_minutes, exercise_goals')
-          .eq('id', sessionIdFromState)
-          .eq('profile_id', session.user.id)
-          .single();
+    const locationState = location.state as any;
+    const sessionIdFromState = locationState?.sessionId;
+    const fromPreSession = locationState?.fromPreSession;
 
-        if (!error && data) {
-          startSession(sessionIdFromState, data.planned_duration_minutes, data.exercise_goals);
-        }
-      };
-      fetchSessionData();
-    }
-  }, [location.state, session?.user]);
+    if (location.pathname !== '/' || !fromPreSession || !session?.user) return;
+
+    const fetchSessionData = async () => {
+      const { data, error } = await supabase
+        .from('sessions')
+        .select('planned_duration_minutes, exercise_goals')
+        .eq('id', sessionIdFromState)
+        .eq('profile_id', session.user.id)
+        .single();
+
+      if (!error && data) {
+        startSession(sessionIdFromState, data.planned_duration_minutes, data.exercise_goals);
+      }
+    };
+    fetchSessionData();
+  }, [location.pathname, location.state, session?.user, navigate]);
 
   // Handle session reset when coming back from PostSessionForm
   useEffect(() => {
@@ -366,7 +375,7 @@ export default function App() {
         sx={{
           width: '100%',
           minHeight: "100%",
-          height: "100%",
+          height: "100%", 
           justifyContent: "start",
           alignItems: "center",
           overflowY: "scroll", 
@@ -379,18 +388,30 @@ export default function App() {
             <Box sx={{ margin: '10px 10px 0 10px', display: 'flex', gap: 1 }} className="account-btns">
               {session && !isRecoverySession ? (
                 <>
-                  <Button 
+                  <Button
                     onClick={() => {
                       if (activeSession) {
+                        endSession();
                         navigate('/post-session', { state: { sessionId } });
                       } else {
                         navigate('/session');
                       }
                     }}
-                    sx={{ backgroundColor: activeSession ? '#ffb5a9' : '#d4ff99' }}
+                    sx={{
+                      backgroundColor: activeSession ? '#d4ff99' : '#d4ff99',
+                      color: '#1a3e00',
+                      borderRadius: '999px',
+                      px: 2,
+                      py: 1,
+                      minWidth: '240px',
+                      boxShadow: '0 4px 10px rgba(0,0,0,0.08)',
+                      '&:hover': {
+                        backgroundColor: '#c7f68e',
+                      }
+                    }}
                     title={activeSession ? "Click to end session" : "Start a new session"}
                   >
-                    {activeSession ? 'Ongoing Session' : 'Start Session'}
+                    {activeSession ? `Ongoing session — ${formatTime(sessionRemainingSeconds)} left` : 'Start Session'}
                   </Button>
                   <Link to="/profile">
                     <Button>

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -53,6 +53,7 @@ export default function App() {
   const [contract, setContract] = useState<ContractData>(BLANK_CONTRACT);
   const [progress, setProgress] = useState<Submission[]>([]);
   const [problemSessionStats, setProblemSessionStats] = useState<Record<string, ProblemSessionStats>>({});
+  const [sessionTimerRunning, setSessionTimerRunning] = useState(false);
 
   const contractProgress: ContractProgress = contract.Coding.problemsToSolveByCategory;
   contractProgress["mutation"] = contract.Mutation.problemsToSolve;
@@ -215,6 +216,7 @@ export default function App() {
     setSessionStartTime(new Date());
     setSessionRemainingSeconds(durationMinutes * 60);
     setActiveSession(true);
+    setSessionTimerRunning(true);
   };
 
   const endSession = () => {
@@ -225,6 +227,7 @@ export default function App() {
     setSessionDuration(0);
     setSessionRemainingSeconds(0);
     setProblemSessionStats({});
+    setSessionTimerRunning(false);
   };
 
   const formatTime = (seconds: number): string => {
@@ -274,8 +277,16 @@ export default function App() {
 
       if (remaining <= 0) {
         clearInterval(sessionTimerRef.current!);
-        // Session ended so the user should be prompted to post-session
-        // Don't navigate automatically maybe, we should let them finish current problem
+        setActiveSession(false);
+        setSessionStartTime(null);
+        setSessionRemainingSeconds(0);
+        setSessionTimerRunning(false);
+        navigate('/post-session', {
+          state: {
+            sessionId,
+            timerExpired: true
+          }
+        });
       }
     }, 1000);
 
@@ -392,10 +403,12 @@ export default function App() {
                 <>
                   <Button
                     onClick={() => {
-                      if (activeSession) {
+                      if (activeSession && sessionTimerRunning) {
                         endSession();
                         navigate('/post-session', { state: { sessionId } });
-                      } else {
+                      } else if (activeSession && !sessionTimerRunning) {
+                        navigate('/post-session', { state: { sessionId } });
+                      }else {
                         navigate('/session');
                       }
                     }}
@@ -413,7 +426,11 @@ export default function App() {
                     }}
                     title={activeSession ? "Click to end session" : "Start a new session"}
                   >
-                    {activeSession ? `Ongoing session — ${formatTime(sessionRemainingSeconds)} left` : 'Start Session'}
+                  {sessionTimerRunning
+                    ? `Ongoing session — ${formatTime(sessionRemainingSeconds)} left`
+                    : activeSession
+                      ? 'Complete Session Reflection'
+                      : 'Start Session'}
                   </Button>
                   <Link to="/profile">
                     <Button>
@@ -474,7 +491,8 @@ export default function App() {
             plannedExerciseCount,
             problemSessionStats,
             setProblemSessionStats,
-            progress
+            progress,
+            sessionTimerRunning
           }} />
         </Box>
         

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -274,8 +274,8 @@ export default function App() {
 
       if (remaining <= 0) {
         clearInterval(sessionTimerRef.current!);
-        // Session ended - user should be prompted to post-session
-        // Don't navigate automatically, let them finish current problem
+        // Session ended so the user should be prompted to post-session
+        // Don't navigate automatically maybe, we should let them finish current problem
       }
     }, 1000);
 
@@ -473,7 +473,8 @@ export default function App() {
             sessionDuration,
             plannedExerciseCount,
             problemSessionStats,
-            setProblemSessionStats
+            setProblemSessionStats,
+            progress
           }} />
         </Box>
         

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -245,6 +245,13 @@ export default function App() {
     }
   }, [location.state, session?.user]);
 
+  // Handle session reset when coming back from PostSessionForm
+  useEffect(() => {
+    if (location.pathname === '/' && activeSession && (location.state as any)?.fromPostSession) {
+      endSession();
+    }
+  }, [location.pathname, location.state, activeSession]);
+
   // Session countdown timer
   useEffect(() => {
     if (!activeSession || !sessionStartTime) return;
@@ -375,7 +382,6 @@ export default function App() {
                   <Button 
                     onClick={() => {
                       if (activeSession) {
-                        endSession();
                         navigate('/post-session', { state: { sessionId } });
                       } else {
                         navigate('/session');

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,3 +178,10 @@ export interface ProblemLog {
   last_attempt_at: string;
   code: unknown;
 }
+
+export interface ProblemSessionStats{
+    elapsedTimeSeconds: number;
+    completed: boolean;
+    passedTests: number;
+    totalTests: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,4 +191,5 @@ export interface ProblemArgs{
     activeSession: boolean;
     problemSessionStats: Record<string, ProblemSessionStats>;
     setProblemSessionStats: React.Dispatch<React.SetStateAction<Record<string, ProblemSessionStats>>>;
+    progress?: Pick<Submission, 'problem_title' | 'passed_tests' | 'total_tests'>[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,4 +161,25 @@ export interface BlogPost {
         author: string;
         title: string;
     };
+  reflection_id: string;
+  session_id: string;
+  reflection_type: "pre" | "post";
+  form_data: FormAnswers;
+  created_at: Date;
+}
+
+export interface ProblemLog {
+  problem_title: string;
+  session_id: string;
+  profile_id: string;
+  problem_category: string;
+  question_type: string;
+  attempt_count: number;
+  successful: boolean;
+  passed_tests: number;
+  total_tests: number;
+  time_spent_seconds: number;
+  first_attempt_at: string;
+  last_attempt_at: string;
+  code: unknown;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,3 +185,10 @@ export interface ProblemSessionStats{
     passedTests: number;
     totalTests: number;
 }
+
+export interface ProblemArgs{
+    problemName: string;
+    activeSession: boolean;
+    problemSessionStats: Record<string, ProblemSessionStats>;
+    setProblemSessionStats: React.Dispatch<React.SetStateAction<Record<string, ProblemSessionStats>>>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,11 +161,6 @@ export interface BlogPost {
         author: string;
         title: string;
     };
-  reflection_id: string;
-  session_id: string;
-  reflection_type: "pre" | "post";
-  form_data: FormAnswers;
-  created_at: Date;
 }
 
 export interface ProblemLog {


### PR DESCRIPTION
This merge tackles but doesn't complete the following issue #160.

#### Changes made in this PR:

- Overall timer counts down  from time selected by user
- In-exercise timer counts up from the moment the user arrives on the page
- In-exercise timer pauses when user leaves the page and resumes when user comes back
- User can hide the in-exercise timer and re-open it
- After user stays on a single exercise for 2/3 of the allocated time (calculated with timer set by student and number of exercises planned to be completed in the session), a small popup alert appears.
- The user can hide the alert
- After the session's timer finished, the user is prompted to answer the post-session form


<img width="1919" height="861" alt="image" src="https://github.com/user-attachments/assets/b3f73e06-dcf9-4cc8-8168-aad6b9af28e6" />

<img width="1153" height="656" alt="image" src="https://github.com/user-attachments/assets/991cd363-995c-47d4-8da9-81bdeecfbe2f" />

<img width="1153" height="659" alt="image" src="https://github.com/user-attachments/assets/81a16545-148f-48aa-a379-9a8b0810744a" />

<img width="1160" height="651" alt="image" src="https://github.com/user-attachments/assets/a1f5bcb5-a28f-45d7-876e-a5588091f87a" />


<img width="1796" height="860" alt="image" src="https://github.com/user-attachments/assets/43a15d3b-5cdd-4209-8684-f6dfef628694" />
